### PR TITLE
generated string session

### DIFF
--- a/backend/utils/tele_sring_session.py
+++ b/backend/utils/tele_sring_session.py
@@ -1,0 +1,17 @@
+from telethon.sync import TelegramClient
+from telethon.sessions import StringSession
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_id = os.getenv("API_ID")
+api_hash = os.getenv("API_HASH")
+phone = os.getenv("PHONE")
+
+# Generates a session string so there is no need to continuously key in a code everytime the scraping is done
+with TelegramClient(StringSession(), api_id, api_hash) as client:
+    print("Logging in...")
+    client.start(phone)
+    print("Your session string is:\n")
+    print(client.session.save())


### PR DESCRIPTION
- rationale: so that whoever runs the scraping doesn't have to keep keying in the code since it is no longer using a username